### PR TITLE
Change Committee class to refer to its parent via the votesmart_id field

### DIFF
--- a/app/models/committees/committee.rb
+++ b/app/models/committees/committee.rb
@@ -2,7 +2,7 @@ class Committee < ActiveRecord::Base
   belongs_to :legislature
   has_many :committee_memberships
   has_many :members, :through => :committee_memberships, :source => :person
-  belongs_to :parent, :class_name => 'Committee'
+  belongs_to :parent, :class_name => 'Committee', :foreign_key => :votesmart_parent_id, :primary_key => :votesmart_id
 
   define_index do
     indexes name, :sortable => true


### PR DESCRIPTION
Add foreign_key and primary_key parameters to this line in the Committee class:

belongs_to :parent, :class_name => 'Committee', :foreign_key => :votesmart_parent_id, :primary_key => :votesmart_id

This seems like what is intended, and fixes a failing spec.
