### PR TITLE
Typo fix on the homepage

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -332,7 +332,7 @@ en:
       join_our_email:    "Join Our Email List"
       more_open_gov:     "More OpenGovernment"
       twitter:           "Twitter& Facebook"
-      wiki_community:    "Wiki Communmnity Project"
+      wiki_community:    "Wiki Community Project"
       tools:             "Tools / Resources / Goodies"
       our_open_code:     "Our Open Code and Data"
       wish_list:         "Wish List / What We Need"


### PR DESCRIPTION
It says "Wiki Communmnity Project", which I'm gonna guess is a typo (or a shameful neologism?)!
