### PR TITLE
Fix for first-time rake install_dev

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -63,7 +63,7 @@ namespace :opengov do
   end
 
   desc "Install clean database: prepare database, fetch all data, load data"
-  task :install => :environment do
+  task :install do
     abcs = ActiveRecord::Base.configurations
 
     unless abcs[Rails.env]["adapter"] == 'postgresql'


### PR DESCRIPTION
Calling "=> :environment" on a rake task requires the Rails app, which in turn tries to connect to the database, thus creating a chicken and egg problem!
